### PR TITLE
Fix Map.get_tile_at() for out-of-bounds coordinates

### DIFF
--- a/client/util.py
+++ b/client/util.py
@@ -107,7 +107,9 @@ class Map(object):
                 snake_at_pos = snake
 
         tile_type = TileType.EMPTY
-        if snake_at_pos:
+        if self.is_coordinate_out_of_bounds(coordinate):
+            tile_type = TileType.WALL
+        elif snake_at_pos:
             if position == snake_at_pos['positions'][0]:
                 tile_type = TileType.SNAKE_HEAD
             elif position == snake_at_pos['positions'][-1]:
@@ -118,8 +120,6 @@ class Map(object):
             tile_type = TileType.OBSTACLE
         elif position in self.game_map['foodPositions']:
             tile_type = TileType.FOOD
-        elif self.is_coordinate_out_of_bounds(coordinate):
-            tile_type = TileType.WALL
 
         return Tile(tile_type, coordinate)
 


### PR DESCRIPTION
Hi!

I fixed `util.Map.get_tile_at()` when `coordinate` is out-of-bounds. Without this PR, because the other branches of the `if` work with `position`, some out-of-bounds coordinates are considered as the first/last cell of the row under/above.